### PR TITLE
Pass `$flat` variable to `woocommerce_order_items_meta_display` filter

### DIFF
--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -100,7 +100,7 @@ class WC_Order_Item_Meta {
 			}
 		}
 
-		$output = apply_filters( 'woocommerce_order_items_meta_display', $output, $this );
+		$output = apply_filters( 'woocommerce_order_items_meta_display', $output, $this, $flat );
 
 		if ( $return ) {
 			return $output;


### PR DESCRIPTION
Allow 3rd parties to determine if output should be flat for the `woocommerce_order_items_meta_display` filter.
